### PR TITLE
feat(vis): add menu toggles for loaded plugins (Closes #36)

### DIFF
--- a/xmms/main.c
+++ b/xmms/main.c
@@ -53,6 +53,9 @@ GtkWidget *mainwin, *mainwin_url_window = NULL, *mainwin_dir_browser = NULL;
 GtkWidget *mainwin_jtt = NULL, *mainwin_jtf = NULL, *mainwin_qm = NULL;
 GtkWidget *mainwin_options_menu, *mainwin_songname_menu, *mainwin_vis_menu;
 GtkWidget *mainwin_general_menu;
+static GtkWidget *mainwin_vis_plugins_sep = NULL;
+static GtkWidget *mainwin_vis_plugins_manage_item = NULL;
+static GList *mainwin_vis_plugin_items = NULL;
 
 /* Globally stored menu item widgets for programmatic toggling */
 static GtkWidget *mi_opt_shuffle = NULL, *mi_opt_repeat = NULL, *mi_opt_npa = NULL;
@@ -206,6 +209,8 @@ GtkItemFactoryEntry mainwin_songname_menu_entries[] = {
 static gint mainwin_songname_menu_entries_num = 0; /* GTK3: entries disabled */
 
 void mainwin_vis_menu_callback(gpointer cb_data, guint action, GtkWidget *w);
+static void mainwin_vis_plugin_menu_cb(GtkCheckMenuItem *item, gpointer data);
+static void mainwin_clear_vis_plugin_menu_items(void);
 
 enum {
     MAINWIN_VIS_ANALYZER,
@@ -2972,6 +2977,74 @@ void mainwin_vis_menu_callback(gpointer cb_data, guint action, GtkWidget *w)
     }
 }
 
+static void mainwin_vis_plugin_menu_cb(GtkCheckMenuItem *item, gpointer data)
+{
+    enable_vis_plugin(GPOINTER_TO_INT(data), gtk_check_menu_item_get_active(item));
+}
+
+static void mainwin_clear_vis_plugin_menu_items(void)
+{
+    GList *node;
+
+    for (node = mainwin_vis_plugin_items; node != NULL; node = node->next)
+        gtk_widget_destroy(GTK_WIDGET(node->data));
+
+    g_list_free(mainwin_vis_plugin_items);
+    mainwin_vis_plugin_items = NULL;
+
+    if (mainwin_vis_plugins_sep) {
+        gtk_widget_destroy(mainwin_vis_plugins_sep);
+        mainwin_vis_plugins_sep = NULL;
+    }
+}
+
+void mainwin_vis_plugins_rescan(void)
+{
+    GList *plugins, *node;
+    GList *children;
+    gint i;
+    gint insert_pos = -1;
+
+    if (mainwin_vis_menu == NULL)
+        return;
+
+    mainwin_clear_vis_plugin_menu_items();
+
+    plugins = get_vis_list();
+    if (plugins == NULL)
+        return;
+
+    children = gtk_container_get_children(GTK_CONTAINER(mainwin_vis_menu));
+    if (mainwin_vis_plugins_manage_item != NULL)
+        insert_pos = g_list_index(children, mainwin_vis_plugins_manage_item);
+    g_list_free(children);
+
+    mainwin_vis_plugins_sep = gtk_separator_menu_item_new();
+    if (insert_pos >= 0)
+        gtk_menu_shell_insert(GTK_MENU_SHELL(mainwin_vis_menu), mainwin_vis_plugins_sep,
+                              insert_pos++);
+    else
+        gtk_menu_shell_append(GTK_MENU_SHELL(mainwin_vis_menu), mainwin_vis_plugins_sep);
+    gtk_widget_show(mainwin_vis_plugins_sep);
+
+    for (node = plugins, i = 0; node != NULL; node = node->next, i++) {
+        VisPlugin *plugin = node->data;
+        GtkWidget *item;
+
+        item = gtk_check_menu_item_new_with_label(plugin->description ? plugin->description : "");
+        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), vis_enabled(i));
+        gtk_widget_set_sensitive(item, !vis_plugin_failed(i));
+        g_signal_connect(item, "toggled", G_CALLBACK(mainwin_vis_plugin_menu_cb),
+                         GINT_TO_POINTER(i));
+        if (insert_pos >= 0)
+            gtk_menu_shell_insert(GTK_MENU_SHELL(mainwin_vis_menu), item, insert_pos++);
+        else
+            gtk_menu_shell_append(GTK_MENU_SHELL(mainwin_vis_menu), item);
+        gtk_widget_show(item);
+        mainwin_vis_plugin_items = g_list_append(mainwin_vis_plugin_items, item);
+    }
+}
+
 void mainwin_general_menu_callback(gpointer cb_data, guint action, GtkWidget *w)
 {
     switch (action) {
@@ -3449,8 +3522,10 @@ void create_popups(void)
     menu_radio_new(sub, "Fastest", &grp, cfg.peaks_falloff == FALLOFF_FASTEST,
                    G_CALLBACK(mainwin_vis_menu_callback), MAINWIN_VIS_PFALLOFF_FASTEST);
 
-    menu_item_new(mainwin_vis_menu, "Visualization Plugins", G_CALLBACK(mainwin_vis_menu_callback),
-                  MAINWIN_VIS_PLUGINS);
+    mainwin_vis_plugins_rescan();
+    mainwin_vis_plugins_manage_item =
+        menu_item_new(mainwin_vis_menu, "Visualization Plugins",
+                      G_CALLBACK(mainwin_vis_menu_callback), MAINWIN_VIS_PLUGINS);
 
     /* ---- General menu ---- */
     mainwin_general_menu = gtk_menu_new();

--- a/xmms/main.h
+++ b/xmms/main.h
@@ -101,6 +101,7 @@ void mainwin_clear_song_info(void);
 void mainwin_set_always_on_top(gboolean always);
 void mainwin_set_volume_diff(gint diff);
 void mainwin_set_balance_diff(gint diff);
+void mainwin_vis_plugins_rescan(void);
 
 void mainwin_show(gboolean);
 void mainwin_real_show(void);

--- a/xmms/prefswin.c
+++ b/xmms/prefswin.c
@@ -1426,6 +1426,8 @@ void prefswin_vplugins_rescan(void)
     gdouble pos;
     gint sel;
 
+    mainwin_vis_plugins_rescan();
+
     if (prefswin == NULL || prefswin_vplugins_list == NULL)
         return;
 

--- a/xmms/visualization.c
+++ b/xmms/visualization.c
@@ -23,6 +23,7 @@
 struct VisPluginData *vp_data;
 extern Vis *active_vis;
 extern SVis *mainwin_svis;
+static GList *vis_failed_list;
 
 GList *get_vis_list(void)
 {
@@ -38,7 +39,6 @@ void vis_disable_plugin(VisPlugin *vp)
 {
     gint i = g_list_index(vp_data->vis_list, vp);
     enable_vis_plugin(i, FALSE);
-    prefswin_vplugins_rescan();
 }
 
 void vis_about(int i)
@@ -96,6 +96,7 @@ void enable_vis_plugin(int i, gboolean enable)
 {
     GList *node = g_list_nth(vp_data->vis_list, i);
     VisPlugin *vp;
+    gboolean changed = FALSE;
 
     if (!node || !(node->data))
         return;
@@ -103,24 +104,50 @@ void enable_vis_plugin(int i, gboolean enable)
 
     if (enable && !g_list_find(vp_data->enabled_list, vp)) {
         vp_data->enabled_list = g_list_append(vp_data->enabled_list, vp);
+        vis_failed_list = g_list_remove(vis_failed_list, vp);
         if (vp->init)
             vp->init();
-        if (get_input_playing() && vp->playback_start)
-            vp->playback_start();
+        if (g_list_find(vp_data->enabled_list, vp)) {
+            if (get_input_playing() && vp->playback_start)
+                vp->playback_start();
+        } else if (!g_list_find(vis_failed_list, vp)) {
+            vis_failed_list = g_list_append(vis_failed_list, vp);
+        }
+        changed = TRUE;
     } else if (!enable && g_list_find(vp_data->enabled_list, vp)) {
+        vis_failed_list = g_list_remove(vis_failed_list, vp);
         vp_data->enabled_list = g_list_remove(vp_data->enabled_list, vp);
         if (get_input_playing() && vp->playback_stop)
             vp->playback_stop();
         if (vp->cleanup)
             vp->cleanup();
+        changed = TRUE;
+    } else if (!enable) {
+        vis_failed_list = g_list_remove(vis_failed_list, vp);
     }
+
+    if (changed)
+        prefswin_vplugins_rescan();
 }
 
 gboolean vis_enabled(int i)
 {
-    return (g_list_find(vp_data->enabled_list, (VisPlugin *)g_list_nth(vp_data->vis_list, i)->data)
-                ? TRUE
-                : FALSE);
+    GList *node = g_list_nth(vp_data->vis_list, i);
+
+    if (!node || !(node->data))
+        return FALSE;
+
+    return g_list_find(vp_data->enabled_list, node->data) != NULL;
+}
+
+gboolean vis_plugin_failed(int i)
+{
+    GList *node = g_list_nth(vp_data->vis_list, i);
+
+    if (!node || !(node->data))
+        return FALSE;
+
+    return g_list_find(vis_failed_list, node->data) != NULL;
 }
 
 gchar *vis_stringify_enabled_list(void)
@@ -164,24 +191,22 @@ void vis_enable_from_stringified_list(gchar *list)
     gchar **plugins, *base;
     GList *node;
     gint i;
-    VisPlugin *vp;
 
     if (!list || !strcmp(list, ""))
         return;
     plugins = g_strsplit(list, ",", 0);
     for (i = 0; plugins[i]; i++) {
+        gint idx = 0;
+
         node = vp_data->vis_list;
         while (node) {
             base = g_basename(((VisPlugin *)node->data)->filename);
             if (!strcmp(plugins[i], base)) {
-                vp = node->data;
-                vp_data->enabled_list = g_list_append(vp_data->enabled_list, (VisPlugin *)vp);
-                if (vp->init)
-                    vp->init();
-                if (get_input_playing() && vp->playback_start)
-                    vp->playback_start();
+                enable_vis_plugin(idx, TRUE);
+                break;
             }
             node = node->next;
+            idx++;
         }
     }
     g_strfreev(plugins);

--- a/xmms/visualization.h
+++ b/xmms/visualization.h
@@ -39,6 +39,7 @@ void vis_configure(int i);
 void vis_playback_start(void);
 void vis_playback_stop(void);
 gboolean vis_enabled(int i);
+gboolean vis_plugin_failed(int i);
 gchar *vis_stringify_enabled_list(void);
 void vis_enable_from_stringified_list(gchar *list);
 void vis_send_data(gint16 pcm_data[2][512], int nch, int length);


### PR DESCRIPTION
## Summary
- add dynamic visualization plugin toggle entries to the main window Visualization menu
- keep the menu and Preferences visualization list in sync when plugins are enabled, disabled, or fail during init
- preserve the existing Visualization Plugins preferences entry for configuration and fallback access

## Testing
- `git diff --check`
- `bash scripts/format-check.sh` *(fails: `clang-format` not installed in container)*
- `cmake -B build-make -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DXMMS_GTK_VERSION=3` *(fails: missing `gtk+-3.0` and `gthread-2.0` development packages)*

Closes #36