### PR TITLE
ci(release): signed apt/dnf/apk package distribution (S3 + CloudFront)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,103 @@
+---
+# XMMS Resurrection — Signed Package Repository Publish
+#
+# After a GitHub Release is published (package.yml attaches the deb/rpm/apk
+# assets), this workflow signs the repository metadata and publishes signed
+# apt / dnf / apk repositories to the TacitSoft S3 + CloudFront distribution.
+#
+# It is INERT until the operator provisions the configuration below, so it is
+# safe to merge ahead of the infrastructure:
+#
+#   Repo variables (Settings → Secrets and variables → Actions → Variables):
+#     PACKAGE_REPO_BUCKET    e.g. packages.tacitsoft.dev
+#     PACKAGE_REPO_BASE_URL  e.g. https://packages.tacitsoft.dev
+#     PACKAGE_REPO_CF_DIST   CloudFront distribution id (optional)
+#     AWS_REGION             e.g. us-west-2
+#     AWS_ROLE_TO_ASSUME     IAM role ARN for OIDC (s3:PutObject + cloudfront)
+#   Repo secrets:
+#     PACKAGE_SIGNING_KEY    ASCII-armored private GPG key (the archive key)
+#     ABUILD_PRIVKEY         (optional) Alpine abuild private key for apk index
+#
+# Until PACKAGE_REPO_BUCKET is set the publish job is skipped.
+
+name: Release Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)publish (e.g. v1.3.0)"
+        required: true
+      dry_run:
+        description: "Build repo metadata but do not push to S3"
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write   # OIDC → AWS
+
+jobs:
+  publish:
+    name: Sign + Publish Repositories
+    runs-on: ubuntu-24.04
+    # Skip cleanly when the distribution endpoint is not yet configured.
+    if: vars.PACKAGE_REPO_BUCKET != ''
+
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      S3_BUCKET: ${{ vars.PACKAGE_REPO_BUCKET }}
+      REPO_BASE_URL: ${{ vars.PACKAGE_REPO_BASE_URL }}
+      CF_DISTRIBUTION_ID: ${{ vars.PACKAGE_REPO_CF_DIST }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install repo tooling
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            reprepro createrepo-c gnupg awscli
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p staging
+          gh release download "$TAG" --repo "${{ github.repository }}" \
+            --pattern '*.deb' --pattern '*.rpm' --pattern '*.apk' \
+            --dir staging
+          echo "Downloaded:"; ls -la staging
+
+      - name: Import signing key
+        env:
+          PACKAGE_SIGNING_KEY: ${{ secrets.PACKAGE_SIGNING_KEY }}
+        run: |
+          if [[ -z "$PACKAGE_SIGNING_KEY" ]]; then
+            echo "::error::PACKAGE_SIGNING_KEY secret is not set"; exit 1
+          fi
+          echo "$PACKAGE_SIGNING_KEY" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons \
+                   | awk -F: '/^sec:/ {print $5; exit}')
+          echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+          echo "Imported key $KEY_ID"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+
+      - name: Build + publish repositories
+        env:
+          STAGING_DIR: ${{ github.workspace }}/staging
+          PUBLISH: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '0' || '1' }}
+        run: bash scripts/publish-repo.sh

--- a/docs/PACKAGE_REPOS.md
+++ b/docs/PACKAGE_REPOS.md
@@ -1,0 +1,74 @@
+# XMMS Package Repositories
+
+Signed apt / dnf / apk repositories published to the TacitSoft S3 + CloudFront
+distribution by [`release-publish.yml`](../.github/workflows/release-publish.yml)
+via [`scripts/publish-repo.sh`](../scripts/publish-repo.sh).
+
+## End-user installation
+
+> Replace `packages.tacitsoft.dev` with the configured `PACKAGE_REPO_BASE_URL`.
+
+### Debian / Ubuntu (apt)
+
+```bash
+curl -fsSL https://packages.tacitsoft.dev/xmms-archive-keyring.asc \
+  | sudo gpg --dearmor -o /usr/share/keyrings/xmms-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/xmms-archive-keyring.gpg] https://packages.tacitsoft.dev/deb stable main" \
+  | sudo tee /etc/apt/sources.list.d/xmms.list
+sudo apt-get update && sudo apt-get install xmms
+```
+
+### Fedora / RHEL (dnf)
+
+```bash
+sudo curl -fsSL https://packages.tacitsoft.dev/rpm/xmms.repo -o /etc/yum.repos.d/xmms.repo
+sudo dnf install xmms
+```
+
+### Alpine (apk)
+
+```bash
+curl -fsSL https://packages.tacitsoft.dev/xmms-archive-keyring.rsa.pub \
+  | sudo tee /etc/apk/keys/xmms-archive-keyring.rsa.pub
+echo "https://packages.tacitsoft.dev/apk" | sudo tee -a /etc/apk/repositories
+sudo apk update && sudo apk add xmms
+```
+
+## Operator setup (one-time)
+
+1. **Archive signing key** — generate an offline GPG key for the repository:
+   ```bash
+   gpg --quick-generate-key "TacitSoft XMMS Archive <packages@tacitsoft.dev>" rsa4096 sign never
+   gpg --armor --export-secret-keys <key-id>   # → store as the PACKAGE_SIGNING_KEY secret
+   ```
+   For Alpine, also generate an `abuild` key (`abuild-keygen -a`) and store the
+   private key as the `ABUILD_PRIVKEY` secret; publish the `.rsa.pub`.
+
+2. **AWS** — create the S3 bucket + CloudFront distribution (origin = bucket),
+   and an IAM role trusted by GitHub OIDC with `s3:PutObject`/`s3:DeleteObject`
+   on the bucket and `cloudfront:CreateInvalidation` on the distribution.
+   (Provision via dagobah-infra Terraform alongside the other static sites.)
+
+3. **GitHub config** — set the repo variables and secrets listed in the
+   workflow header (`PACKAGE_REPO_BUCKET`, `PACKAGE_REPO_BASE_URL`,
+   `PACKAGE_REPO_CF_DIST`, `AWS_REGION`, `AWS_ROLE_TO_ASSUME`,
+   `PACKAGE_SIGNING_KEY`, `ABUILD_PRIVKEY`).
+
+4. **Validate** — `workflow_dispatch` the publish with `dry_run: true` against an
+   existing tag; confirm the repo tree is built before a real publish.
+
+## Local dry run
+
+```bash
+STAGING_DIR=dist GPG_KEY_ID=<key> \
+  S3_BUCKET=example REPO_BASE_URL=https://example \
+  bash scripts/publish-repo.sh        # PUBLISH unset → dry run, no S3
+```
+
+## Security notes
+
+- The archive private key never lives in the repo; it is injected at publish
+  time from the `PACKAGE_SIGNING_KEY` secret and used only to sign metadata.
+- apt verifies the `Release` signature, dnf verifies `repomd.xml.asc`
+  (`repo_gpgcheck=1`), apk verifies the signed `APKINDEX`.
+- AWS access is short-lived via OIDC — no long-lived keys in CI.

--- a/scripts/publish-repo.sh
+++ b/scripts/publish-repo.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# publish-repo.sh — sign XMMS packages and publish signed apt/dnf/apk
+# repositories to the TacitSoft S3 + CloudFront distribution.
+#
+# Consumes already-built packages (the .deb/.rpm/.apk produced by package.yml)
+# from a staging directory, signs the repository metadata with the archive GPG
+# key, lays out standard repo trees, syncs them to S3, and invalidates the
+# CloudFront cache.
+#
+# This script is deployment-agnostic: every environment-specific value comes
+# from the environment, so nothing is hard-coded. It is a no-op-safe dry run
+# unless PUBLISH=1 is set.
+#
+# Required environment:
+#   STAGING_DIR      Directory containing the input packages (recursively).
+#   GPG_KEY_ID       Long key id / fingerprint of the imported archive key.
+#   S3_BUCKET        Target bucket name (e.g. packages.tacitsoft.dev).
+#   REPO_BASE_URL    Public base URL (e.g. https://packages.tacitsoft.dev).
+# Optional:
+#   CF_DISTRIBUTION_ID   CloudFront distribution to invalidate after sync.
+#   APT_SUITE            apt suite name (default: stable).
+#   APT_COMPONENT        apt component (default: main).
+#   WORK_DIR             Build scratch dir (default: mktemp).
+#   ABUILD_PRIVKEY       Path to abuild private key for Alpine signing.
+#   PUBLISH              "1" to actually push to S3/CloudFront (default: dry run).
+#
+set -euo pipefail
+
+# --- Config / validation ----------------------------------------------------
+: "${STAGING_DIR:?set STAGING_DIR to the directory holding built packages}"
+: "${GPG_KEY_ID:?set GPG_KEY_ID to the archive signing key id}"
+: "${S3_BUCKET:?set S3_BUCKET to the target bucket}"
+: "${REPO_BASE_URL:?set REPO_BASE_URL to the public repo URL}"
+
+APT_SUITE="${APT_SUITE:-stable}"
+APT_COMPONENT="${APT_COMPONENT:-main}"
+PUBLISH="${PUBLISH:-0}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
+REPO_OUT="${WORK_DIR}/repo"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+
+# Architecture mapping is x86_64/amd64 only for now (matches package.yml).
+mkdir -p "${REPO_OUT}"
+
+# Export the public key once — every package manager needs it to verify.
+gpg --armor --export "${GPG_KEY_ID}" > "${REPO_OUT}/xmms-archive-keyring.asc"
+log "Exported public key to xmms-archive-keyring.asc"
+
+# --- APT (Debian/Ubuntu) ----------------------------------------------------
+build_apt() {
+    local debs
+    debs=$(find "${STAGING_DIR}" -name '*.deb' | sort)
+    [ -z "${debs}" ] && { log "apt: no .deb found — skipping"; return 0; }
+
+    local aptroot="${REPO_OUT}/deb"
+    mkdir -p "${aptroot}/conf"
+    cat > "${aptroot}/conf/distributions" <<EOF
+Origin: TacitSoft
+Label: XMMS Resurrection
+Suite: ${APT_SUITE}
+Codename: ${APT_SUITE}
+Architectures: amd64 source
+Components: ${APT_COMPONENT}
+Description: XMMS Resurrection package repository
+SignWith: ${GPG_KEY_ID}
+EOF
+    local d
+    while IFS= read -r d; do
+        [ -n "${d}" ] || continue
+        log "apt: including $(basename "${d}")"
+        reprepro -b "${aptroot}" includedeb "${APT_SUITE}" "${d}"
+    done <<< "${debs}"
+    # reprepro keeps its db under the root; drop it from what we publish.
+    rm -rf "${aptroot}/conf" "${aptroot}/db"
+}
+
+# --- DNF (Fedora/RHEL) ------------------------------------------------------
+build_dnf() {
+    local rpms
+    rpms=$(find "${STAGING_DIR}" -name '*.rpm' ! -name '*.src.rpm' | sort)
+    [ -z "${rpms}" ] && { log "dnf: no .rpm found — skipping"; return 0; }
+
+    local rpmroot="${REPO_OUT}/rpm"
+    mkdir -p "${rpmroot}"
+    local r
+    while IFS= read -r r; do
+        [ -n "${r}" ] || continue
+        cp -f "${r}" "${rpmroot}/"
+    done <<< "${rpms}"
+
+    createrepo_c --update "${rpmroot}"
+    # Sign repomd.xml (dnf verifies this detached signature with repo_gpgcheck=1).
+    gpg --batch --yes --local-user "${GPG_KEY_ID}" \
+        --detach-sign --armor "${rpmroot}/repodata/repomd.xml"
+    log "dnf: signed repodata/repomd.xml.asc"
+
+    # Drop a ready-to-use .repo file for end users.
+    cat > "${rpmroot}/xmms.repo" <<EOF
+[xmms]
+name=XMMS Resurrection
+baseurl=${REPO_BASE_URL}/rpm
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=${REPO_BASE_URL}/xmms-archive-keyring.asc
+EOF
+}
+
+# --- APK (Alpine) -----------------------------------------------------------
+build_apk() {
+    local apks
+    apks=$(find "${STAGING_DIR}" -name '*.apk' | sort)
+    [ -z "${apks}" ] && { log "apk: no .apk found — skipping"; return 0; }
+    if [ -z "${ABUILD_PRIVKEY:-}" ]; then
+        log "apk: ABUILD_PRIVKEY unset — copying packages without an index"
+    fi
+
+    local apkroot="${REPO_OUT}/apk/x86_64"
+    mkdir -p "${apkroot}"
+    local a
+    while IFS= read -r a; do
+        [ -n "${a}" ] || continue
+        cp -f "${a}" "${apkroot}/"
+    done <<< "${apks}"
+
+    if command -v apk >/dev/null 2>&1 && [ -n "${ABUILD_PRIVKEY:-}" ]; then
+        ( cd "${apkroot}" && apk index -o APKINDEX.tar.gz ./*.apk )
+        abuild-sign -k "${ABUILD_PRIVKEY}" "${apkroot}/APKINDEX.tar.gz"
+        log "apk: built + signed APKINDEX.tar.gz"
+    fi
+}
+
+build_apt
+build_dnf
+build_apk
+
+# --- Publish ----------------------------------------------------------------
+log "Repository tree built under ${REPO_OUT}"
+find "${REPO_OUT}" -type f | sort | sed 's/^/    /'
+
+if [ "${PUBLISH}" != "1" ]; then
+    log "DRY RUN (PUBLISH != 1) — not syncing to S3. Set PUBLISH=1 to publish."
+    exit 0
+fi
+
+log "Syncing to s3://${S3_BUCKET}/ ..."
+aws s3 sync "${REPO_OUT}/" "s3://${S3_BUCKET}/" --delete --no-progress
+
+if [ -n "${CF_DISTRIBUTION_ID:-}" ]; then
+    log "Invalidating CloudFront ${CF_DISTRIBUTION_ID} ..."
+    aws cloudfront create-invalidation \
+        --distribution-id "${CF_DISTRIBUTION_ID}" \
+        --paths '/*' >/dev/null
+fi
+log "Publish complete: ${REPO_BASE_URL}"


### PR DESCRIPTION
## Summary
Item 4 of the modernization sweep — the signed package **distribution** pipeline to the TacitSoft public repos.

- **`scripts/publish-repo.sh`** — signs repo metadata with the archive GPG key and builds standard repo trees: apt (reprepro → `InRelease`/`Release.gpg`), dnf (createrepo_c → signed `repomd.xml.asc` + `xmms.repo`), apk (signed `APKINDEX`). Syncs to S3, invalidates CloudFront. Dry-run-safe.
- **`.github/workflows/release-publish.yml`** — on `release: published` (or dispatch), downloads the release assets, imports the signing key, assumes AWS via OIDC, publishes. **Inert until configured** (skips when `PACKAGE_REPO_BUCKET` is unset), so safe to merge now.
- **`docs/PACKAGE_REPOS.md`** — end-user install (apt/dnf/apk) + operator one-time setup.

## Verification
Dry-ran `publish-repo.sh` locally against the existing `dist/` packages — produced a correctly signed apt repo, signed dnf repo, and apk tree. shellcheck + yamllint clean.

## Operator prerequisites (before first real publish)
1. Generate the archive GPG key (+ Alpine abuild key) → store as secrets.
2. Provision S3 bucket + CloudFront + OIDC IAM role (Terraform in dagobah-infra).
3. Set repo vars/secrets (`PACKAGE_REPO_BUCKET`, `PACKAGE_REPO_BASE_URL`, `PACKAGE_REPO_CF_DIST`, `AWS_REGION`, `AWS_ROLE_TO_ASSUME`, `PACKAGE_SIGNING_KEY`, `ABUILD_PRIVKEY`).
4. Dispatch with `dry_run: true` against a tag to validate, then go live.

Completes the distribution half of the xmms release goal; pairs with the ARC runner work (dagobah-infra#74, xmms#51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)